### PR TITLE
Use crypto economics to solve the anonamous gas problem

### DIFF
--- a/zoe/contract/mixer.sol
+++ b/zoe/contract/mixer.sol
@@ -72,6 +72,7 @@ contract Mixer {
         success = false;
         bytes20 addr_byte = bytes20(addr);
         bytes memory pub = new bytes(128);
+        uint256 withdrawFee = 3141592 * 2;
         uint i;
         for (i = 0; i < 32; i++) pub[i] = serial[i];
         for (i = 0; i < 20; i++) pub[32 + i] = addr_byte[i];
@@ -84,7 +85,7 @@ contract Mixer {
                     return false;
                 }
                 serials[serial] = true;
-                if (!addr.send(1 ether)) {
+                if (!addr.send(1 ether - withdrawFee) || ! msg.sender.send(withdrawFee)) {
                     throw;
                 }
                 else {


### PR DESCRIPTION
https://github.com/zcash/babyzoe/issues/1 can be fixed by using crypto economics. 

This PR doubles the gas and gives that as a fee to whoever calls `withdraw` this should result in it being profitable for actors to call withdrawals for uses can not pay the gas themselves.

This users only needs to share the `proof` with the caller. Who then calls it and gets `3141592 * 2` wei for their trouble.